### PR TITLE
Replace folder select with hover-expandable list

### DIFF
--- a/apps/web/src/components/folders/select-folder.tsx
+++ b/apps/web/src/components/folders/select-folder.tsx
@@ -1,19 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { CreateFolderDialog } from "./create-folder-dialog";
 import { EditFolderDialog } from "./edit-folder-dialog";
 import { DeleteFolderButton } from "./delete-folder-button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
-} from "../ui/select";
 import type { Folder } from "@/app/bookmarks/page";
-import { BookmarkIcon, ImageIcon, LayoutPanelLeftIcon } from "lucide-react";
+import { BookmarkIcon, LayoutPanelLeftIcon } from "lucide-react";
+import { AnimatePresence, motion } from "motion/react";
 
 export const SelectFolder = ({
   selectedFolder,
@@ -24,11 +17,32 @@ export const SelectFolder = ({
   setSelectedFolder: (folder: Folder | null) => void;
   folders: Folder[];
 }) => {
-  const [open, setOpen] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const leaveTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleMouseEnter = useCallback(() => {
+    if (leaveTimeout.current) {
+      clearTimeout(leaveTimeout.current);
+      leaveTimeout.current = null;
+    }
+    setExpanded(true);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    leaveTimeout.current = setTimeout(() => {
+      setExpanded(false);
+    }, 200);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (leaveTimeout.current) clearTimeout(leaveTimeout.current);
+    };
+  }, []);
 
   useEffect(() => {
     const handleKeyPress = (event: KeyboardEvent) => {
-      // Don't trigger if an input field is focused
       const activeElement = document.activeElement;
       if (
         activeElement &&
@@ -39,10 +53,9 @@ export const SelectFolder = ({
         return;
       }
 
-      // Check if pressed key is a number from 1-9
       const keyNumber = parseInt(event.key);
       if (keyNumber >= 1 && keyNumber <= 9 && folders) {
-        const folderIndex = keyNumber - 1; // Convert to 0-based index
+        const folderIndex = keyNumber - 1;
         const targetFolder = folders[folderIndex];
 
         if (targetFolder) {
@@ -51,10 +64,8 @@ export const SelectFolder = ({
       }
     };
 
-    // Add event listener
     document.addEventListener("keydown", handleKeyPress);
 
-    // Cleanup function to remove event listener
     return () => {
       document.removeEventListener("keydown", handleKeyPress);
     };
@@ -64,89 +75,136 @@ export const SelectFolder = ({
     return <div />;
   }
 
+  const otherFolders = folders?.filter((f) => f.id !== selectedFolder?.id);
+
   return (
-    <Select
-      open={open}
-      onOpenChange={setOpen}
-      value={selectedFolder?.id ?? undefined}
-      onValueChange={(value) => {
-        const newFolder = folders?.find((folder) => folder.id === value);
-
-        if (newFolder) {
-          setSelectedFolder(newFolder);
-        }
-      }}
+    <div
+      ref={containerRef}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      className="relative select-none"
     >
-      <SelectTrigger className="w-fit transition-colors duration-100 cursor-pointer border-none bg-transparent dark:bg-transparent hover:bg-neutral-200/50 dark:hover:bg-neutral-800/50 focus-visible:ring-0 focus-visible:ring-offset-0 select-none shadow-none">
-        <SelectValue placeholder="Select a folder" className="select-none ">
-          <div className="flex items-center gap-2">
-            {selectedFolder?.icon && <p>{selectedFolder.icon}</p>}
-            <p className="font-medium">{selectedFolder?.name}</p>
-          </div>
-        </SelectValue>
-      </SelectTrigger>
-      <SelectContent
-        align="start"
-        side="bottom"
-        sideOffset={4}
-        alignOffset={8}
-        className="min-w-56 max-w-auto"
-      >
-        {folders?.map((folder, index) => (
-          <SelectItem
-            key={folder.id}
-            value={folder.id}
-            className="cursor-pointer select-none flex items-center h-9 justify-between w-full group"
-          >
-            <div className="flex items-center gap-2.5">
-              {folder.icon && <span className="text-sm">{folder.icon}</span>}
-              <span className="text-sm">{folder.name}</span>
-            </div>
+      {/* Selected folder - always visible */}
+      <div className="flex items-center gap-2 px-3 py-1.5 cursor-default">
+        {selectedFolder?.icon && (
+          <p className="text-sm">{selectedFolder.icon}</p>
+        )}
+        <p className="font-medium text-sm">{selectedFolder?.name}</p>
+      </div>
 
-            <div
-              className={`absolute ${
-                selectedFolder?.id !== folder.id
-                  ? "right-1.5"
-                  : "right-[1.9rem]"
-              } flex items-center gap-2`}
+      {/* Expandable folder list */}
+      <AnimatePresence>
+        {expanded && otherFolders.length > 0 && (
+          <motion.div
+            className="flex flex-col gap-0.5 mt-0.5"
+            initial="collapsed"
+            animate="expanded"
+            exit="collapsed"
+            variants={{
+              expanded: {
+                transition: {
+                  staggerChildren: 0.03,
+                },
+              },
+              collapsed: {
+                transition: {
+                  staggerChildren: 0.02,
+                  staggerDirection: -1,
+                },
+              },
+            }}
+          >
+            {otherFolders.map((folder, index) => (
+              <motion.button
+                key={folder.id}
+                onClick={() => {
+                  setSelectedFolder(folder);
+                  setExpanded(false);
+                }}
+                className="flex items-center justify-between gap-4 px-3 py-1.5 rounded-lg cursor-pointer backdrop-blur-xl bg-white/50 dark:bg-neutral-900/50 border border-white/20 dark:border-white/[0.06] hover:bg-white/70 dark:hover:bg-neutral-800/60 transition-colors duration-100 text-left"
+                variants={{
+                  expanded: {
+                    opacity: 1,
+                    y: 0,
+                    filter: "blur(0px)",
+                  },
+                  collapsed: {
+                    opacity: 0,
+                    y: -8,
+                    filter: "blur(4px)",
+                  },
+                }}
+                transition={{
+                  type: "spring",
+                  stiffness: 400,
+                  damping: 30,
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  {folder.icon && (
+                    <span className="text-sm">{folder.icon}</span>
+                  )}
+                  <span className="text-sm">{folder.name}</span>
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <span className="text-[11px] text-muted-foreground/50 tabular-nums">
+                    {folder.totalItems}
+                  </span>
+                  {folder.type === "canvas" ? (
+                    <LayoutPanelLeftIcon className="size-2.5 stroke-[1.5] text-muted-foreground/50 fill-current/10 dark:fill-current/20" />
+                  ) : (
+                    <BookmarkIcon className="size-2.5 stroke-[1.5] text-muted-foreground/50 fill-current/10 dark:fill-current/20" />
+                  )}
+                  <span className="flex text-[10px] items-center justify-center bg-white/40 dark:bg-white/[0.06] rounded-[3px] py-[1px] px-1 border border-black/[0.04] dark:border-white/[0.06] tabular-nums font-mono">
+                    {folders.indexOf(folder) + 1}
+                  </span>
+                </div>
+              </motion.button>
+            ))}
+
+            {/* Actions */}
+            <motion.div
+              className="flex flex-col gap-0.5 mt-1 pt-1 border-t border-black/[0.04] dark:border-white/[0.06]"
+              variants={{
+                expanded: { opacity: 1, y: 0 },
+                collapsed: { opacity: 0, y: -4 },
+              }}
+              transition={{
+                type: "spring",
+                stiffness: 400,
+                damping: 30,
+              }}
             >
-              <span className="text-[11px] text-muted-foreground/50 tabular-nums">
-                {folder.totalItems}
-              </span>
-              {folder.type === "canvas" ? (
-                <LayoutPanelLeftIcon className="size-2.5 stroke-[1.5] text-muted-foreground/50 fill-current/10 dark:fill-current/20" />
-              ) : (
-                <BookmarkIcon className="size-2.5 stroke-[1.5] text-muted-foreground/50 fill-current/10 dark:fill-current/20" />
+              <div className="rounded-lg backdrop-blur-xl bg-white/50 dark:bg-neutral-900/50 border border-white/20 dark:border-white/[0.06]">
+                <CreateFolderDialog
+                  setSelectedFolder={setSelectedFolder}
+                  setSelectOpen={setExpanded}
+                />
+              </div>
+              {selectedFolder && (
+                <div className="rounded-lg backdrop-blur-xl bg-white/50 dark:bg-neutral-900/50 border border-white/20 dark:border-white/[0.06]">
+                  <EditFolderDialog
+                    folder={selectedFolder}
+                    setSelectedFolder={setSelectedFolder}
+                    setSelectOpen={setExpanded}
+                  />
+                </div>
               )}
-              {selectedFolder?.id !== folder.id && (
-                <span className="flex text-[10px] items-center justify-center bg-muted/50 rounded-[3px] py-[1px] px-1 border border-border/30 group-hover:bg-transparent group-hover:border-transparent tabular-nums font-mono">
-                  {index + 1}
-                </span>
+              {selectedFolder?.id && (
+                <div className="rounded-lg backdrop-blur-xl bg-white/50 dark:bg-neutral-900/50 border border-white/20 dark:border-white/[0.06]">
+                  <DeleteFolderButton
+                    folderId={selectedFolder.id}
+                    setOpen={setExpanded}
+                    folders={folders}
+                    setSelectedFolder={setSelectedFolder}
+                  />
+                </div>
               )}
-            </div>
-          </SelectItem>
-        ))}
-        <SelectSeparator />
-        <CreateFolderDialog
-          setSelectedFolder={setSelectedFolder}
-          setSelectOpen={setOpen}
-        />
-        {selectedFolder && (
-          <EditFolderDialog
-            folder={selectedFolder}
-            setSelectedFolder={setSelectedFolder}
-            setSelectOpen={setOpen}
-          />
+            </motion.div>
+          </motion.div>
         )}
-        {selectedFolder?.id && (
-          <DeleteFolderButton
-            folderId={selectedFolder.id}
-            setOpen={setOpen}
-            folders={folders}
-            setSelectedFolder={setSelectedFolder}
-          />
-        )}
-      </SelectContent>
-    </Select>
+      </AnimatePresence>
+    </div>
   );
 };


### PR DESCRIPTION
## Summary
- Replaces the Radix UI `<Select>` dropdown in the folder selector with a custom hover-expandable inline list
- On hover, other folders animate in with staggered spring animations and a `backdrop-blur` glassmorphism effect (similar to macOS widgets), making items readable over canvas content
- Folders float without a container surface — each item has its own blur background and subtle border
- Preserves keyboard shortcuts (1-9), folder actions (create/edit/delete), and all existing functionality

## Test plan
- [ ] Hover over the folder name → other folders expand below with animation
- [ ] Move mouse away → list collapses after short delay
- [ ] Click a different folder → selects it and collapses
- [ ] Press 1-9 → selects corresponding folder
- [ ] Create/Edit/Delete folder actions still work
- [ ] Verify blur effect over canvas content
- [ ] Check dark mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)